### PR TITLE
Add dynamic styles to process media queries and viewport units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 yarn-error.log
 .coverage
+.idea
+package-lock.json

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -100,7 +100,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default.wrapper },
+    { style: require('react-native-dynamic-style-processor').process(_Button2.default).wrapper },
     React.createElement(
       Text,
       null,
@@ -134,7 +134,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default['main-wrapper'], _Grid2.default['left-column']] },
+    { style: [require('react-native-dynamic-style-processor').process(_Button2.default)['main-wrapper'], require('react-native-dynamic-style-processor').process(_Grid2.default)['left-column']] },
     React.createElement(
       Text,
       null,
@@ -168,7 +168,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Grid2.default.column] },
+    { style: [require('react-native-dynamic-style-processor').process(_Button2.default).wrapper, require('react-native-dynamic-style-processor').process(_Grid2.default).column] },
     React.createElement(
       Text,
       null,
@@ -202,7 +202,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Grid2.default.column, { height: 1 }] },
+    { style: [require('react-native-dynamic-style-processor').process(_Button2.default).wrapper, require('react-native-dynamic-style-processor').process(_Grid2.default).column, { height: 1 }] },
     React.createElement(
       Text,
       null,
@@ -241,7 +241,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Text2.default.wrapper, _Button2.default.wrapper, _Grid2.default.wrapper] },
+    { style: [require('react-native-dynamic-style-processor').process(_Text2.default).wrapper, require('react-native-dynamic-style-processor').process(_Button2.default).wrapper, require('react-native-dynamic-style-processor').process(_Grid2.default).wrapper] },
     React.createElement(
       Text,
       null,
@@ -275,7 +275,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Grid2.default.column] },
+    { style: [require('react-native-dynamic-style-processor').process(_Button2.default).wrapper, require('react-native-dynamic-style-processor').process(_Grid2.default).column] },
     React.createElement(
       Text,
       null,
@@ -304,7 +304,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default[\\"main-wrapper\\"] },
+    { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"main-wrapper\\"] },
     React.createElement(
       Text,
       null,
@@ -333,7 +333,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default.wrapper },
+    { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper },
     React.createElement(
       Text,
       null,
@@ -362,7 +362,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default[\\"main-wrapper\\"], _Button2.default[\\"red-bg\\"]] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"main-wrapper\\"], require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"red-bg\\"]] },
     React.createElement(
       Text,
       null,
@@ -391,7 +391,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Button2.default.red] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper, require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).red] },
     React.createElement(
       Text,
       null,
@@ -471,7 +471,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default.wrapper },
+    { style: require('react-native-dynamic-style-processor').process(_Button2.default).wrapper },
     React.createElement(
       Text,
       null,
@@ -503,7 +503,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default.wrapper },
+    { style: require('react-native-dynamic-style-processor').process(_Button2.default).wrapper },
     React.createElement(
       Text,
       null,
@@ -532,7 +532,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Button2.default.red, { marginTop: 10 }] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper, require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).red, { marginTop: 10 }] },
     React.createElement(
       Text,
       null,
@@ -561,7 +561,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Button2.default.red] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper, require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).red] },
     React.createElement(
       Text,
       null,
@@ -590,7 +590,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, _Button2.default.red] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper, require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).red] },
     React.createElement(
       Text,
       null,
@@ -619,7 +619,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default[\\"main-wrapper\\"], _Button2.default[\\"red-bg\\"], _Button2.default[\\"something-else\\"]] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"main-wrapper\\"], require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"red-bg\\"], require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"something-else\\"]] },
     React.createElement(
       Text,
       null,
@@ -651,10 +651,10 @@ var Foo = function Foo() {
     { style: { width: \\"100%\\" } },
     React.createElement(
       View,
-      { style: _Button2.default.wrapper },
+      { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper },
       React.createElement(
         Text,
-        { style: _Button2.default.red },
+        { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).red },
         \\"Foo\\"
       )
     )
@@ -681,7 +681,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: [_Button2.default.wrapper, { marginTop: 10 }] },
+    { style: [require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper, { marginTop: 10 }] },
     React.createElement(
       Text,
       null,
@@ -713,7 +713,7 @@ var Foo = function Foo() {
     null,
     React.createElement(
       View,
-      { style: _Button2.default.wrapper },
+      { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper },
       React.createElement(
         Text,
         null,
@@ -722,7 +722,7 @@ var Foo = function Foo() {
     ),
     React.createElement(
       View,
-      { style: _Button2.default.dark },
+      { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).dark },
       React.createElement(
         Text,
         null,
@@ -752,7 +752,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default.wrapper },
+    { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default).wrapper },
     React.createElement(
       Text,
       null,
@@ -781,7 +781,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Foo = function Foo() {
   return React.createElement(
     View,
-    { style: _Button2.default[\\"main-wrapper\\"] },
+    { style: require(\\"react-native-dynamic-style-processor\\").process(_Button2.default)[\\"main-wrapper\\"] },
     React.createElement(
       Text,
       null,

--- a/index.js
+++ b/index.js
@@ -10,6 +10,18 @@ module.exports = function(babel) {
   var specifier = null;
   var randomSpecifier = null;
   var t = babel.types;
+
+  function generateRequire(expression) {
+    var require = t.callExpression(t.identifier("require"), [
+      t.stringLiteral("react-native-dynamic-style-processor")
+    ]);
+    expression.object = t.callExpression(
+      t.memberExpression(require, t.identifier("process")),
+      [expression.object]
+    );
+    return expression;
+  }
+
   return {
     post() {
       randomSpecifier = null;
@@ -82,11 +94,12 @@ module.exports = function(babel) {
               var prop = hasParts ? parts[1] : c;
               var hasHyphen = /\w+-\w+/.test(prop) === true;
 
-              return t.memberExpression(
+              var memberExpression = t.memberExpression(
                 t.identifier(obj),
                 hasHyphen ? t.stringLiteral(prop) : t.identifier(prop),
                 hasHyphen
               );
+              return generateRequire(memberExpression);
             })
             .filter(e => e !== undefined);
 

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
         "statements": 75
       }
     }
+  },
+  "dependencies": {
+    "react-native-dynamic-style-processor": "^0.10.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,10 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+css-viewport-units-transform@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/css-viewport-units-transform/-/css-viewport-units-transform-0.10.1.tgz#a043ee456893770404b1468ac44d7f0cea57d018"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -1157,6 +1161,10 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deepmerge@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -3022,6 +3030,10 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
+micro-memoize@^2.0.1, micro-memoize@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-2.0.3.tgz#5122131971eae6c69249a8a63a91b7b5cee20111"
+
 micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -3613,6 +3625,21 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-native-css-media-query-processor@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-native-css-media-query-processor/-/react-native-css-media-query-processor-0.14.0.tgz#e99f13c721dbf92b522bd4f1116c0da4fb54f8fa"
+  dependencies:
+    deepmerge "^2.1.0"
+    micro-memoize "^2.0.1"
+
+react-native-dynamic-style-processor@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/react-native-dynamic-style-processor/-/react-native-dynamic-style-processor-0.10.0.tgz#2e507d9e2b57a54c6c509de3af7d7c2da6397a6c"
+  dependencies:
+    css-viewport-units-transform "^0.10.1"
+    micro-memoize "^2.0.3"
+    react-native-css-media-query-processor "^0.14.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
hi @kristerkari 

Added support for your media queries and viewports dynamic styles

I don't know if it makes sense to merge it into this repo itself or create a new one called `*-to-dynamic-style`.

I would vote to just merge it in here, since `@media` support is a pretty essential part of the CSS and btw `babel-plugin-react-css-modules` also have the runtime `JSXExpression` handling enabled by default (https://github.com/gajus/babel-plugin-react-css-modules/tree/c4f4ea073e56e5af451b348de0a8e0f14368456e#runtime-stylename-resolution).

I'm also going to implement the universal support for `JSXExpression` later. The similar way it's done in https://github.com/gajus/babel-plugin-react-css-modules/blob/master/src/getClassName.js. And will make another PR.